### PR TITLE
Added missing #include<vector> in pomdp_sigma_cpu.h

### DIFF
--- a/include/nova/pomdp/utilities/pomdp_sigma_cpu.h
+++ b/include/nova/pomdp/utilities/pomdp_sigma_cpu.h
@@ -29,6 +29,7 @@
 #include <nova/pomdp/pomdp.h>
 
 #include <utility>
+#include <vector>
 
 namespace nova {
 


### PR DESCRIPTION
Code wouldn't compile without include: 
![image](https://user-images.githubusercontent.com/15518585/59108376-9ef90200-8932-11e9-969f-2bc9f674dfef.png)
