### PR TITLE
ubuntu 20.04 capable code

### DIFF
--- a/src/pomdp/utilities/pomdp_sigma_cpu.cpp
+++ b/src/pomdp/utilities/pomdp_sigma_cpu.cpp
@@ -26,6 +26,7 @@
 
 #include <stdio.h>
 #include <algorithm>
+#include <vector>
 
 #include <nova/error_codes.h>
 #include <nova/constants.h>


### PR DESCRIPTION
#include <vector> required by gcc on ubuntu 20.04.